### PR TITLE
fix: avoid repeated DateFormatter allocation in ReadingStreakTracker

### DIFF
--- a/FeedReader/ReadingStreakTracker.swift
+++ b/FeedReader/ReadingStreakTracker.swift
@@ -373,18 +373,23 @@ class ReadingStreakTracker {
 
     // MARK: - Private: Date Helpers
 
-    private func dateKey(for date: Date) -> String {
+    /// Reusable date formatter — DateFormatter is expensive to create and
+    /// was previously allocated on every dateKey() / parseDate() call.
+    /// computeStats() calls these in tight loops making the overhead
+    /// significant (DateFormatter init involves locale + ICU setup).
+    private lazy var iso8601DayFormatter: DateFormatter = {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd"
         fmt.calendar = calendar
-        return fmt.string(from: date)
+        return fmt
+    }()
+
+    private func dateKey(for date: Date) -> String {
+        return iso8601DayFormatter.string(from: date)
     }
 
     private func parseDate(_ key: String) -> Date? {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd"
-        fmt.calendar = calendar
-        return fmt.date(from: key)
+        return iso8601DayFormatter.date(from: key)
     }
 
     private func daysBetween(_ from: Date, _ to: Date) -> Int {


### PR DESCRIPTION
## Problem

`dateKey(for:)` and `parseDate(_:)` in `ReadingStreakTracker` created a new `DateFormatter` on every call. `DateFormatter` initialization is expensive — it involves locale resolution and ICU setup. These methods are called in tight loops inside `computeStats()` (iterating all sorted dates), `weeklySummaries()` (iterating weeks × 7 days), and streak computation (backward day scan).

For a user with 200+ daily records, a single `getStats()` call could create 400+ `DateFormatter` instances.

## Fix

Replaced per-call allocation with a single `lazy var` formatter instance. Reduces formatter allocations from O(n) to O(1) per stats computation.