### PR TITLE
fix: OPML parser loses category for feeds after nested folders

### DIFF
--- a/FeedReader/OPMLManager.swift
+++ b/FeedReader/OPMLManager.swift
@@ -219,7 +219,9 @@ private class OPMLParser: NSObject, XMLParserDelegate {
     
     private let data: Data
     private var outlines: [OPMLOutline] = []
-    private var currentCategory: String?
+    /// Stack of folder names for nested category tracking.
+    /// Feeds inherit the nearest enclosing folder as their category.
+    private var categoryStack: [String] = []
     private var outlineDepth = 0
     
     init(data: Data) {
@@ -248,8 +250,9 @@ private class OPMLParser: NSObject, XMLParserDelegate {
         
         // Check if this is a category/folder outline (has children, no xmlUrl)
         if attributeDict["xmlUrl"] == nil && attributeDict["xmlurl"] == nil {
-            // This is a folder — remember it as category context
-            currentCategory = attributeDict["text"] ?? attributeDict["title"]
+            // This is a folder — push it onto the category stack
+            let folderName = attributeDict["text"] ?? attributeDict["title"]
+            categoryStack.append(folderName ?? "")
             return
         }
         
@@ -268,7 +271,7 @@ private class OPMLParser: NSObject, XMLParserDelegate {
             title: title,
             xmlUrl: feedUrl,
             htmlUrl: htmlUrl,
-            category: currentCategory
+            category: categoryStack.last(where: { !$0.isEmpty })
         )
         
         outlines.append(outline)
@@ -278,13 +281,15 @@ private class OPMLParser: NSObject, XMLParserDelegate {
                 didEndElement elementName: String,
                 namespaceURI: String?,
                 qualifiedName qName: String?) {
-        // When leaving an outline element, track depth and clear category
-        // when exiting a top-level folder outline (depth 1).
-        if elementName.lowercased() == "outline" {
-            if outlineDepth == 1 {
-                currentCategory = nil
-            }
-            outlineDepth -= 1
+        guard elementName.lowercased() == "outline" else { return }
+        // Pop category stack when leaving a folder outline.
+        // Folder outlines pushed onto the stack in didStartElement;
+        // feed outlines (with xmlUrl) did not push, so we only pop
+        // when the depth matches the stack depth (i.e., this closing
+        // tag corresponds to a folder, not a feed).
+        if categoryStack.count >= outlineDepth {
+            categoryStack.removeLast()
         }
+        outlineDepth -= 1
     }
 }

--- a/FeedReaderTests/OPMLTests.swift
+++ b/FeedReaderTests/OPMLTests.swift
@@ -536,6 +536,37 @@ class OPMLTests: XCTestCase {
         XCTAssertNil(outlines[3].category)
     }
     
+    func testParseNestedFoldersPreserveCategoryCorrectly() {
+        // Regression: nested folders should use a stack, not a single variable.
+        // Feeds in an outer folder after a nested folder should retain the
+        // outer folder's category, not nil.
+        let opml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <opml version="2.0">
+          <body>
+            <outline text="Tech">
+              <outline type="rss" text="TC" xmlUrl="https://techcrunch.com/feed/"/>
+              <outline text="Apple">
+                <outline type="rss" text="9to5Mac" xmlUrl="https://9to5mac.com/feed/"/>
+              </outline>
+              <outline type="rss" text="Ars" xmlUrl="https://arstechnica.com/feed/"/>
+            </outline>
+            <outline type="rss" text="Root" xmlUrl="https://example.com/root.xml"/>
+          </body>
+        </opml>
+        """
+        
+        let outlines = opmlManager.parseOPML(opml)
+        XCTAssertEqual(outlines.count, 4)
+        XCTAssertEqual(outlines[0].title, "TC")
+        XCTAssertEqual(outlines[0].category, "Tech")
+        XCTAssertEqual(outlines[1].title, "9to5Mac")
+        XCTAssertEqual(outlines[1].category, "Apple", "Feed in nested folder should have inner folder category")
+        XCTAssertEqual(outlines[2].title, "Ars")
+        XCTAssertEqual(outlines[2].category, "Tech", "Feed in outer folder after nested folder should retain outer category")
+        XCTAssertNil(outlines[3].category, "Root-level feed should have nil category")
+    }
+    
     func testParseLargeOPML() {
         var opml = """
         <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Problem

The OPML parser used a single `currentCategory` variable to track which folder a feed belongs to. This broke with nested folders — after exiting a nested folder, feeds in the outer folder lost their category (set to nil instead of the outer folder name).

## Fix

Replace the single `currentCategory` variable with a `categoryStack` array. Folder outlines push onto the stack when opened and pop when closed, correctly tracking nested folder hierarchy. Feeds inherit the nearest enclosing folder via `categoryStack.last`.

## Test

Added `testParseNestedFoldersPreserveCategoryCorrectly` — verifies feeds in outer folders retain their category after a nested folder closes.
