### PR TITLE
fix: narrow TEST-NET SSRF checks to correct /24 ranges

### DIFF
--- a/FeedReader/URLValidator.swift
+++ b/FeedReader/URLValidator.swift
@@ -122,7 +122,7 @@ enum URLValidator {
 
     /// Check if an IPv4 address string falls in a private/reserved range.
     private static func isPrivateIPv4(_ ip: String) -> Bool {
-        guard let (a, b, _, _) = parseIPv4(ip) else { return false }
+        guard let (a, b, c, _) = parseIPv4(ip) else { return false }
 
         // 127.0.0.0/8 — Loopback
         if a == 127 { return true }
@@ -139,11 +139,11 @@ enum URLValidator {
         // 0.0.0.0/8 — "This" network
         if a == 0 { return true }
         // 192.0.2.0/24 — TEST-NET-1
-        if a == 192 && b == 0 { return true }
+        if a == 192 && b == 0 && c == 2 { return true }
         // 198.51.100.0/24 — TEST-NET-2
-        if a == 198 && b == 51 { return true }
+        if a == 198 && b == 51 && c == 100 { return true }
         // 203.0.113.0/24 — TEST-NET-3
-        if a == 203 && b == 0 { return true }
+        if a == 203 && b == 0 && c == 113 { return true }
         // 255.255.255.255 — Broadcast
         if a == 255 { return true }
 


### PR DESCRIPTION
## Problem

The SSRF protection in \URLValidator.isPrivateIPv4\ was overly broad for the three TEST-NET documentation ranges:

- **192.0.2.0/24** (TEST-NET-1) was checking \ == 192 && b == 0\, blocking the entire \192.0.0.0/16\ range
- **198.51.100.0/24** (TEST-NET-2) was checking \ == 198 && b == 51\, blocking the entire \198.51.0.0/16\ range  
- **203.0.113.0/24** (TEST-NET-3) was checking \ == 203 && b == 0\, blocking the entire \203.0.0.0/16\ range

This means legitimate public IP addresses like \192.0.1.1\, \198.51.50.1\, or \203.0.1.1\ would be incorrectly rejected as private/reserved, preventing feeds hosted on those IPs from being added.

## Fix

Added the third octet (\c\) to each check so they match only the actual /24 CIDR blocks as specified in RFC 5737.