### PR TITLE
fix: use Calendar date arithmetic in streak calculation (DST bug)

### DIFF
--- a/FeedReader/ArticleSpacedReview.swift
+++ b/FeedReader/ArticleSpacedReview.swift
@@ -551,7 +551,12 @@ class ArticleSpacedReview {
     // MARK: - Streaks
 
     /// Calculate current consecutive review streak.
+    ///
+    /// Uses `Calendar` to subtract days instead of raw `TimeInterval(-86400)`,
+    /// which could skip or double-count days across DST transitions (where a
+    /// "day" is 23 or 25 hours).
     func currentStreak(at date: Date = Date()) -> Int {
+        let calendar = Calendar.current
         var streak = 0
         var checkDate = date
 
@@ -559,19 +564,25 @@ class ArticleSpacedReview {
         let todayStr = Self.dateString(from: checkDate)
         if !reviewDates.contains(todayStr) {
             // Check yesterday — streak might still be alive
-            checkDate = checkDate.addingTimeInterval(-86400)
+            guard let yesterday = calendar.date(byAdding: .day, value: -1, to: checkDate) else {
+                return 0
+            }
+            checkDate = yesterday
             let yesterdayStr = Self.dateString(from: checkDate)
             if !reviewDates.contains(yesterdayStr) {
                 return 0
             }
         }
 
-        // Count backwards
+        // Count backwards using calendar arithmetic
         while true {
             let dateStr = Self.dateString(from: checkDate)
             if reviewDates.contains(dateStr) {
                 streak += 1
-                checkDate = checkDate.addingTimeInterval(-86400)
+                guard let prevDay = calendar.date(byAdding: .day, value: -1, to: checkDate) else {
+                    break
+                }
+                checkDate = prevDay
             } else {
                 break
             }


### PR DESCRIPTION
## Problem

\currentStreak()\ in \ArticleSpacedReview.swift\ used \ddingTimeInterval(-86400)\ to walk backwards through days when counting the review streak. This is incorrect because:

- **Spring forward (DST):** A day is only 23 hours, so subtracting 86400s lands in the previous calendar day's 23:00 — potentially skipping a day
- **Fall back (DST):** A day is 25 hours, so subtracting 86400s lands at 01:00 of the same calendar day — causing an infinite loop or double-count

## Fix

Replaced raw \TimeInterval\ arithmetic with \Calendar.date(byAdding: .day, value: -1, to:)\, which correctly handles DST transitions, leap seconds, and all calendar edge cases.