### PR TITLE
refactor: extract shared JSONCoding utility for encoder/decoder setup

### DIFF
--- a/FeedReader/ArticleCollectionManager.swift
+++ b/FeedReader/ArticleCollectionManager.swift
@@ -330,9 +330,7 @@ class ArticleCollectionManager {
 
     /// Export all collections as JSON data.
     func exportAsJSON() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(collections)
     }
 
@@ -340,8 +338,7 @@ class ArticleCollectionManager {
     /// Returns the number of collections imported.
     @discardableResult
     func importFromJSON(_ data: Data) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let imported = try? decoder.decode([ArticleCollection].self, from: data) else { return 0 }
 
         var importedCount = 0
@@ -435,8 +432,7 @@ class ArticleCollectionManager {
     // MARK: - Persistence
 
     private func saveCollections() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(collections) {
             UserDefaults.standard.set(data, forKey: metadataKey)
         }
@@ -449,8 +445,7 @@ class ArticleCollectionManager {
             return
         }
 
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         if let loaded = try? decoder.decode([ArticleCollection].self, from: data) {
             collections = loaded
             rebuildArticleIndex()

--- a/FeedReader/ArticleFlashcardGenerator.swift
+++ b/FeedReader/ArticleFlashcardGenerator.swift
@@ -622,9 +622,7 @@ class ArticleFlashcardGenerator {
             sessionHistory: sessionHistory,
             reviewDates: reviewDates
         )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
+        let encoder = JSONCoding.iso8601PrettyUnsortedEncoder
         guard let jsonData = try? encoder.encode(data) else { return nil }
         return String(data: jsonData, encoding: .utf8)
     }
@@ -632,8 +630,7 @@ class ArticleFlashcardGenerator {
     /// Import data from JSON.
     func importJSON(_ json: String) -> Bool {
         guard let jsonData = json.data(using: .utf8) else { return false }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let data = try? decoder.decode(PersistenceData.self, from: jsonData) else { return false }
 
         for card in data.cards {

--- a/FeedReader/ArticleSpacedReview.swift
+++ b/FeedReader/ArticleSpacedReview.swift
@@ -484,10 +484,7 @@ class ArticleSpacedReview {
     /// Export all review data as JSON.
     func exportJSON() -> String {
         let allItems = self.allItems()
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(allItems),
               let json = String(data: data, encoding: .utf8) else {
             return "[]"
@@ -594,8 +591,7 @@ class ArticleSpacedReview {
             reviewDates: Array(reviewDates),
             longestStreak: longestStreak
         )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(model) {
             try? data.write(to: Self.fileURL, options: .atomic)
         }
@@ -603,8 +599,7 @@ class ArticleSpacedReview {
 
     private func load() {
         guard let data = try? Data(contentsOf: Self.fileURL) else { return }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let model = try? decoder.decode(StorageModel.self, from: data) else { return }
 
         items = [:]

--- a/FeedReader/ContentCalendar.swift
+++ b/FeedReader/ContentCalendar.swift
@@ -549,9 +549,7 @@ class ContentCalendar {
     /// Export calendar data as JSON.
     func exportJSON(referenceDate: Date = Date()) -> String? {
         let report = generateReport(referenceDate: referenceDate)
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(report) else { return nil }
         return String(data: data, encoding: .utf8)
     }

--- a/FeedReader/ContentFilterManager.swift
+++ b/FeedReader/ContentFilterManager.swift
@@ -315,9 +315,7 @@ class ContentFilterManager {
     
     /// Export all filters as JSON string.
     func exportFilters() -> String {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
+        let encoder = JSONCoding.iso8601PrettyUnsortedEncoder
         guard let data = try? encoder.encode(filters),
               let json = String(data: data, encoding: .utf8) else {
             return "[]"
@@ -334,9 +332,7 @@ class ContentFilterManager {
             return result
         }
         
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
+        let decoder = JSONCoding.iso8601Decoder
         guard let imported = try? decoder.decode([ContentFilter].self, from: data) else {
             result.errors = 1
             return result

--- a/FeedReader/FeedAutomationEngine.swift
+++ b/FeedReader/FeedAutomationEngine.swift
@@ -618,9 +618,7 @@ class FeedAutomationEngine {
     
     /// Export all rules as JSON data.
     func exportRules() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(rules)
     }
     
@@ -634,8 +632,7 @@ class FeedAutomationEngine {
     /// Set `replace` to true to clear existing rules first.
     @discardableResult
     func importRules(from data: Data, replace: Bool = false) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let imported = try? decoder.decode([AutomationRule].self, from: data) else {
             return 0
         }

--- a/FeedReader/FeedBundleManager.swift
+++ b/FeedReader/FeedBundleManager.swift
@@ -356,16 +356,13 @@ class FeedBundleManager {
     /// Export a bundle to JSON data.
     func exportBundle(id: String) -> Data? {
         guard let bundle = bundle(withId: id) else { return nil }
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.epochPrettyEncoder
         return try? encoder.encode(bundle)
     }
 
     /// Import a bundle from JSON data.
     func importBundle(from data: Data) -> FeedBundle? {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoder = JSONCoding.epochDecoder
         guard var bundle = try? decoder.decode(FeedBundle.self, from: data) else {
             return nil
         }
@@ -417,8 +414,7 @@ class FeedBundleManager {
 
     private func saveCustomBundles() {
         let custom = bundles.filter { !$0.isBuiltIn }
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
+        let encoder = JSONCoding.epochEncoder
         if let data = try? encoder.encode(custom) {
             UserDefaults.standard.set(data, forKey: FeedBundleManager.customBundlesKey)
         }
@@ -427,8 +423,7 @@ class FeedBundleManager {
     private func loadCustomBundles() {
         guard let data = UserDefaults.standard.data(
             forKey: FeedBundleManager.customBundlesKey) else { return }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoder = JSONCoding.epochDecoder
         if let custom = try? decoder.decode([FeedBundle].self, from: data) {
             bundles.append(contentsOf: custom)
         }

--- a/FeedReader/FeedHealthManager.swift
+++ b/FeedReader/FeedHealthManager.swift
@@ -544,9 +544,7 @@ class FeedHealthManager {
     // MARK: - Persistence
     
     private func saveData() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
-        
+        let encoder = JSONCoding.epochEncoder
         if let recordsData = try? encoder.encode(records) {
             UserDefaults.standard.set(recordsData, forKey: FeedHealthManager.recordsKey)
         }
@@ -562,9 +560,7 @@ class FeedHealthManager {
     }
     
     private func loadData() {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-        
+        let decoder = JSONCoding.epochDecoder
         if let data = UserDefaults.standard.data(forKey: FeedHealthManager.recordsKey),
            let loaded = try? decoder.decode([String: [FetchRecord]].self, from: data) {
             records = loaded

--- a/FeedReader/FeedMergeManager.swift
+++ b/FeedReader/FeedMergeManager.swift
@@ -363,16 +363,13 @@ class FeedMergeManager {
 
     /// Export all merged feeds as JSON data.
     func exportJSON() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(mergedFeeds)
     }
 
     /// Import merged feeds from JSON data. Appends to existing, skipping duplicates by id.
     func importJSON(_ data: Data) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let imported = try? decoder.decode([MergedFeed].self, from: data) else { return 0 }
         let existingIds = Set(mergedFeeds.map { $0.id })
         var count = 0
@@ -389,16 +386,14 @@ class FeedMergeManager {
     // MARK: - Persistence
 
     func save() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(mergedFeeds) {
             try? data.write(to: Self.storageURL, options: .atomic)
         }
     }
 
     func load() {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let data = try? Data(contentsOf: Self.storageURL),
               let feeds = try? decoder.decode([MergedFeed].self, from: data) else { return }
         self.mergedFeeds = feeds

--- a/FeedReader/FeedPrivacyGuard.swift
+++ b/FeedReader/FeedPrivacyGuard.swift
@@ -789,17 +789,14 @@ class FeedPrivacyGuard {
     /// Export scans as JSON data.
     func exportJSON() -> Data? {
         let exportable = scanCache.values.map { ArticlePrivacyScanData(from: $0) }
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(exportable)
     }
 
     /// Import scans from JSON data.
     @discardableResult
     func importJSON(_ data: Data) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let imported = try? decoder.decode([ArticlePrivacyScanData].self, from: data) else {
             return 0
         }

--- a/FeedReader/FeedSubscriptionAnalyzer.swift
+++ b/FeedReader/FeedSubscriptionAnalyzer.swift
@@ -696,9 +696,7 @@ class FeedSubscriptionAnalyzer {
 
     /// Export subscription timeline as JSON data.
     func exportTimeline() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(data)
     }
 
@@ -730,8 +728,7 @@ class FeedSubscriptionAnalyzer {
     // MARK: - Persistence
 
     private func saveData() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let encoded = try? encoder.encode(data) {
             UserDefaults.standard.set(encoded, forKey: storageKey)
         }
@@ -739,8 +736,7 @@ class FeedSubscriptionAnalyzer {
 
     private func loadData() {
         guard let saved = UserDefaults.standard.data(forKey: storageKey) else { return }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         if let decoded = try? decoder.decode(SubscriptionData.self, from: saved) {
             data = decoded
         }

--- a/FeedReader/FeedUpdateScheduler.swift
+++ b/FeedReader/FeedUpdateScheduler.swift
@@ -322,15 +322,13 @@ class FeedUpdateScheduler {
 
     /// Encodes all schedules to JSON data for storage.
     func serialize() throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         return try encoder.encode(schedules)
     }
 
     /// Restores schedules from JSON data.
     static func deserialize(from data: Data, dateProvider: @escaping () -> Date = { Date() }) throws -> FeedUpdateScheduler {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         let schedules = try decoder.decode([String: FeedSchedule].self, from: data)
         return FeedUpdateScheduler(schedules: schedules, dateProvider: dateProvider)
     }

--- a/FeedReader/JSONCoding.swift
+++ b/FeedReader/JSONCoding.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Shared, pre-configured `JSONEncoder` and `JSONDecoder` instances.
+///
+/// `JSONEncoder.encode()` and `JSONDecoder.decode()` are safe to call
+/// from any thread because each call creates its own internal state.
+/// The top-level encoder/decoder objects are stateless after initial
+/// configuration, so sharing them avoids redundant allocations.
+enum JSONCoding {
+
+    // MARK: - ISO 8601 Date Strategy
+
+    /// Encoder with ISO 8601 dates, pretty-printed with sorted keys.
+    ///
+    /// Equivalent to:
+    /// ```swift
+    /// let encoder = JSONEncoder()
+    /// encoder.dateEncodingStrategy = .iso8601
+    /// encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    /// ```
+    static let iso8601PrettyEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+
+    /// Encoder with ISO 8601 dates, pretty-printed (no sorted keys).
+    static let iso8601PrettyUnsortedEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = .prettyPrinted
+        return e
+    }()
+
+    /// Encoder with ISO 8601 dates, compact output.
+    static let iso8601Encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    /// Decoder with ISO 8601 date strategy.
+    static let iso8601Decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    // MARK: - Epoch (Seconds Since 1970) Date Strategy
+
+    /// Encoder with epoch dates, pretty-printed with sorted keys.
+    static let epochPrettyEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .secondsSince1970
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+
+    /// Encoder with epoch dates, compact output.
+    static let epochEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .secondsSince1970
+        return e
+    }()
+
+    /// Decoder with epoch date strategy.
+    static let epochDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .secondsSince1970
+        return d
+    }()
+}

--- a/FeedReader/ReadingAchievementsManager.swift
+++ b/FeedReader/ReadingAchievementsManager.swift
@@ -555,17 +555,14 @@ class ReadingAchievementsManager {
 
     /// Export progress as JSON data.
     func exportJSON() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(Array(progressMap.values))
     }
 
     /// Import progress from JSON data. Returns number of entries imported.
     @discardableResult
     func importJSON(_ data: Data) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let entries = try? decoder.decode([AchievementProgress].self, from: data) else { return 0 }
         var count = 0
         for entry in entries {

--- a/FeedReader/ReadingChallengeManager.swift
+++ b/FeedReader/ReadingChallengeManager.swift
@@ -716,8 +716,7 @@ class ReadingChallengeManager {
 
     /// Export all challenges as a JSON string.
     func exportJSON(prettyPrint: Bool = true) -> String? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if prettyPrint {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         }
@@ -729,8 +728,7 @@ class ReadingChallengeManager {
     /// - Returns: Number of challenges imported (skips duplicates by ID).
     @discardableResult
     func importJSON(_ jsonString: String) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let data = jsonString.data(using: .utf8),
               let imported = try? decoder.decode([ReadingChallenge].self, from: data) else {
             return 0

--- a/FeedReader/ReadingDataExporter.swift
+++ b/FeedReader/ReadingDataExporter.swift
@@ -292,8 +292,7 @@ class ReadingDataExporter {
             )
         )
         
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if options.prettyPrint {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         }
@@ -338,9 +337,7 @@ class ReadingDataExporter {
             )
         }
 
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
+        let decoder = JSONCoding.iso8601Decoder
         let archive: ReadingDataArchive
         do {
             archive = try decoder.decode(ReadingDataArchive.self, from: data)
@@ -501,9 +498,7 @@ class ReadingDataExporter {
             return ["Archive too large (\(sizeMB) MB). Maximum allowed: \(limitMB) MB."]
         }
 
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
+        let decoder = JSONCoding.iso8601Decoder
         var errors: [String] = []
         
         do {
@@ -603,9 +598,7 @@ class ReadingDataExporter {
     
     /// Get a summary of what's in an archive without importing.
     func previewArchive(_ data: Data) -> ArchivePreview? {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
+        let decoder = JSONCoding.iso8601Decoder
         guard let archive = try? decoder.decode(ReadingDataArchive.self, from: data) else {
             return nil
         }

--- a/FeedReader/ReadingHabitsProfiler.swift
+++ b/FeedReader/ReadingHabitsProfiler.swift
@@ -667,18 +667,14 @@ class ReadingHabitsProfiler {
     /// Export profile as JSON string.
     func exportProfileJSON() -> String? {
         let profile = generateProfile()
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(profile) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 
     /// Export events as JSON string.
     func exportEventsJSON() -> String? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(events) else { return nil }
         return String(data: data, encoding: .utf8)
     }

--- a/FeedReader/ReadingHistoryManager.swift
+++ b/FeedReader/ReadingHistoryManager.swift
@@ -467,17 +467,14 @@ class ReadingHistoryManager {
     
     /// Export history as JSON data.
     func exportAsJSON() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
+        let encoder = JSONCoding.iso8601PrettyUnsortedEncoder
         return try? encoder.encode(entries)
     }
     
     // MARK: - Persistence
     
     private func save() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(entries) {
             UserDefaults.standard.set(data, forKey: ReadingHistoryManager.userDefaultsKey)
         }
@@ -489,8 +486,7 @@ class ReadingHistoryManager {
             entryIndex = [:]
             return
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         if let loaded = try? decoder.decode([HistoryEntry].self, from: data) {
             entries = loaded.sorted { $0.lastVisitedAt > $1.lastVisitedAt }
             rebuildIndex()

--- a/FeedReader/ReadingInsightsGenerator.swift
+++ b/FeedReader/ReadingInsightsGenerator.swift
@@ -409,9 +409,7 @@ class ReadingInsightsGenerator {
 
     /// Export a report as a JSON string.
     func exportAsJSON(_ report: InsightReport) -> String? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(report) else { return nil }
         return String(data: data, encoding: .utf8)
     }
@@ -719,8 +717,7 @@ class ReadingInsightsGenerator {
 
     private func save() {
         let storage = Storage(reports: reports)
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         guard let data = try? encoder.encode(storage) else { return }
         try? data.write(to: fileURL, options: .atomic)
     }

--- a/FeedReader/ReadingMoodTracker.swift
+++ b/FeedReader/ReadingMoodTracker.swift
@@ -370,9 +370,7 @@ final class ReadingMoodTracker {
             totalEntries: entries.count,
             entries: entries.sorted { $0.date > $1.date }
         )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(export)
     }
 
@@ -452,14 +450,12 @@ final class ReadingMoodTracker {
     private func loadEntries() {
         guard FileManager.default.fileExists(atPath: storageURL.path),
               let data = try? Data(contentsOf: storageURL) else { return }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         entries = (try? decoder.decode([MoodEntry].self, from: data)) ?? []
     }
 
     private func saveEntries() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(entries) {
             try? data.write(to: storageURL)
         }

--- a/FeedReader/ReadingQueueManager.swift
+++ b/FeedReader/ReadingQueueManager.swift
@@ -431,8 +431,7 @@ class ReadingQueueManager {
     // MARK: - Persistence
 
     private func save() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
+        let encoder = JSONCoding.epochEncoder
         if let data = try? encoder.encode(items) {
             UserDefaults.standard.set(data, forKey: ReadingQueueManager.storageKey)
         }
@@ -441,8 +440,7 @@ class ReadingQueueManager {
     private func loadQueue() {
         guard let data = UserDefaults.standard.data(
             forKey: ReadingQueueManager.storageKey) else { return }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoder = JSONCoding.epochDecoder
         if let loaded = try? decoder.decode([QueueItem].self, from: data) {
             items = loaded
             rebuildIndex()

--- a/FeedReader/ReadingSessionTracker.swift
+++ b/FeedReader/ReadingSessionTracker.swift
@@ -389,9 +389,7 @@ class ReadingSessionTracker {
 
     /// Export session history as JSON data.
     func exportAsJSON() -> Data? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         return try? encoder.encode(sessions)
     }
 

--- a/FeedReader/ReadingSpeedTracker.swift
+++ b/FeedReader/ReadingSpeedTracker.swift
@@ -433,17 +433,14 @@ class ReadingSpeedTracker {
 
     /// Export speed data as JSON.
     func exportJSON() -> String? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(samples) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 
     /// Import speed data from JSON (merges with existing, deduplicates by ID).
     func importJSON(_ jsonString: String) -> Int {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         guard let data = jsonString.data(using: .utf8),
               let imported = try? decoder.decode([SpeedSample].self, from: data)
         else { return 0 }

--- a/FeedReader/ReadingStatsManager.swift
+++ b/FeedReader/ReadingStatsManager.swift
@@ -242,8 +242,7 @@ class ReadingStatsManager {
     // MARK: - Persistence
     
     private func save() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONCoding.iso8601Encoder
         if let data = try? encoder.encode(events) {
             UserDefaults.standard.set(data, forKey: ReadingStatsManager.userDefaultsKey)
         }
@@ -254,8 +253,7 @@ class ReadingStatsManager {
             events = []
             return
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let decoder = JSONCoding.iso8601Decoder
         if let loaded = try? decoder.decode([ReadEvent].self, from: data) {
             events = loaded
         } else {

--- a/FeedReader/SentimentTrendsTracker.swift
+++ b/FeedReader/SentimentTrendsTracker.swift
@@ -451,9 +451,7 @@ class SentimentTrendsTracker {
 
     /// Export all samples as JSON.
     func exportJSON() -> String? {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoder = JSONCoding.iso8601PrettyEncoder
         guard let data = try? encoder.encode(samples) else { return nil }
         return String(data: data, encoding: .utf8)
     }


### PR DESCRIPTION
JSONEncoder and JSONDecoder instances were allocated and configured identically across 24 Swift files with repetitive 2-3 line setup patterns.

## New: `JSONCoding` enum

7 pre-configured static instances:

| Instance | Date Strategy | Output Formatting |
|----------|--------------|-------------------|
| `iso8601PrettyEncoder` | ISO 8601 | prettyPrinted + sortedKeys |
| `iso8601PrettyUnsortedEncoder` | ISO 8601 | prettyPrinted |
| `iso8601Encoder` | ISO 8601 | compact |
| `iso8601Decoder` | ISO 8601 | — |
| `epochPrettyEncoder` | secondsSince1970 | prettyPrinted + sortedKeys |
| `epochEncoder` | secondsSince1970 | compact |
| `epochDecoder` | secondsSince1970 | — |

## Impact

- **57 multi-line setup blocks replaced** across 24 files
- **Net: -10 lines** (130 added, 140 removed)
- Plain `JSONEncoder()`/`JSONDecoder()` (no date config) left unchanged
