### PR TITLE
fix: SSRF IPv4 range checks over-blocking ~196K valid addresses

### DIFF
--- a/FeedReader/URLValidator.swift
+++ b/FeedReader/URLValidator.swift
@@ -122,7 +122,7 @@ enum URLValidator {
 
     /// Check if an IPv4 address string falls in a private/reserved range.
     private static func isPrivateIPv4(_ ip: String) -> Bool {
-        guard let (a, b, _, _) = parseIPv4(ip) else { return false }
+        guard let (a, b, c, _) = parseIPv4(ip) else { return false }
 
         // 127.0.0.0/8 — Loopback
         if a == 127 { return true }
@@ -139,11 +139,11 @@ enum URLValidator {
         // 0.0.0.0/8 — "This" network
         if a == 0 { return true }
         // 192.0.2.0/24 — TEST-NET-1
-        if a == 192 && b == 0 { return true }
+        if a == 192 && b == 0 && c == 2 { return true }
         // 198.51.100.0/24 — TEST-NET-2
-        if a == 198 && b == 51 { return true }
+        if a == 198 && b == 51 && c == 100 { return true }
         // 203.0.113.0/24 — TEST-NET-3
-        if a == 203 && b == 0 { return true }
+        if a == 203 && b == 0 && c == 113 { return true }
         // 255.255.255.255 — Broadcast
         if a == 255 { return true }
 

--- a/FeedReaderTests/URLValidatorTests.swift
+++ b/FeedReaderTests/URLValidatorTests.swift
@@ -179,6 +179,38 @@ final class URLValidatorTests: XCTestCase {
         XCTAssertFalse(URLValidator.isSafe("http://203.0.113.1/"))
     }
 
+    // MARK: - SSRF: addresses outside test-net /24 ranges are allowed
+
+    func testNonTestNet1Allowed() {
+        // 192.0.1.1 is NOT in 192.0.2.0/24 — should be allowed
+        XCTAssertTrue(URLValidator.isSafe("http://192.0.1.1/path"))
+    }
+
+    func testNonTestNet1OtherSubnetAllowed() {
+        // 192.0.3.1 is NOT in 192.0.2.0/24
+        XCTAssertTrue(URLValidator.isSafe("http://192.0.3.1/"))
+    }
+
+    func testNonTestNet2Allowed() {
+        // 198.51.99.1 is NOT in 198.51.100.0/24
+        XCTAssertTrue(URLValidator.isSafe("http://198.51.99.1/"))
+    }
+
+    func testNonTestNet2OtherSubnetAllowed() {
+        // 198.51.101.1 is NOT in 198.51.100.0/24
+        XCTAssertTrue(URLValidator.isSafe("http://198.51.101.1/"))
+    }
+
+    func testNonTestNet3Allowed() {
+        // 203.0.112.1 is NOT in 203.0.113.0/24
+        XCTAssertTrue(URLValidator.isSafe("http://203.0.112.1/"))
+    }
+
+    func testNonTestNet3OtherSubnetAllowed() {
+        // 203.0.114.1 is NOT in 203.0.113.0/24
+        XCTAssertTrue(URLValidator.isSafe("http://203.0.114.1/"))
+    }
+
     // MARK: - validateFeedURL
 
     func testValidateFeedURLPublic() {


### PR DESCRIPTION
`isPrivateIPv4()` destructured the IP tuple as `(a, b, _, _)` — ignoring the third octet entirely.
This caused three /24 TEST-NET ranges to over-match their entire /16 supernet:

| Range | Should block | Actually blocked |
|---|---|---|
| `192.0.2.0/24` (256 IPs) | `192.0.2.*` | `192.0.*.*` (65,536 IPs) |
| `198.51.100.0/24` (256 IPs) | `198.51.100.*` | `198.51.*.*` (65,536 IPs) |
| `203.0.113.0/24` (256 IPs) | `203.0.113.*` | `203.0.*.*` (65,536 IPs) |

**Impact:** ~196,000 legitimate public IP addresses were incorrectly flagged as private/reserved, causing valid feed URLs to be rejected.

**Fix:** Destructure `(a, b, c, _)` and add third-octet checks for the three /24 ranges.

**Tests:** 6 regression tests added — verify addresses just outside each /24 boundary are correctly allowed.
