### PR TITLE
fix(ci): CI now correctly fails on build/test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
-            | xcpretty || true
+            | xcpretty
 
       - name: Run tests with code coverage
         run: |
@@ -76,7 +76,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath TestResults \
-            | xcpretty || true
+            | xcpretty
 
       - name: Extract code coverage report
         if: always()
@@ -205,7 +205,7 @@ jobs:
 
       - name: Run SPM tests with coverage
         run: |
-          swift test --enable-code-coverage 2>&1 || true
+          swift test --enable-code-coverage 2>&1
 
       - name: Extract SPM coverage
         run: |


### PR DESCRIPTION
**Problem:** Build and test steps in CI had \|| true\ appended, meaning CI always reported success even when compilation failed or tests broke. Broken PRs could be merged without detection.

**Fix:** Removed \|| true\ from the three critical steps:
- \xcodebuild build\ 
- \xcodebuild test\
- \swift test\ (SPM job)

**Kept \|| true\ where appropriate:**
- \esolvePackageDependencies\ (non-critical pre-step, may fail harmlessly)
- Coverage extraction (advisory, guarded with \if: always()\)
- SwiftLint (already uses \continue-on-error: true\)