### PR TITLE
fix: estimatedTimeToEmpty reports 'Queue empty' for non-empty queues

### DIFF
--- a/FeedReader/OfflineCacheManager.swift
+++ b/FeedReader/OfflineCacheManager.swift
@@ -289,7 +289,7 @@ class OfflineCacheManager {
         guard !cachedArticles.isEmpty else { return }
         let removed = cachedArticles.removeLast()
         cacheIndex.remove(removed.story.link)
-        _totalSizeBytes -= removed.estimatedSizeBytes
+        _totalSizeBytes = max(0, _totalSizeBytes - removed.estimatedSizeBytes)
     }
 
     // MARK: - Persistence

--- a/FeedReader/ReadingQueueManager.swift
+++ b/FeedReader/ReadingQueueManager.swift
@@ -390,8 +390,10 @@ class ReadingQueueManager {
 
     /// Estimated time to clear the pending queue (formatted).
     func estimatedTimeToEmpty() -> String {
-        let minutes = pendingItems().reduce(0.0) { $0 + $1.estimatedReadingTimeMinutes }
-        if minutes < 1 { return "Queue empty" }
+        let pending = pendingItems()
+        guard !pending.isEmpty else { return "Queue empty" }
+        let minutes = pending.reduce(0.0) { $0 + $1.estimatedReadingTimeMinutes }
+        if minutes < 1 { return "<1min" }
         if minutes < 60 { return "\(Int(minutes.rounded()))min" }
         let hours = Int(minutes / 60)
         let mins = Int(minutes.truncatingRemainder(dividingBy: 60))


### PR DESCRIPTION
## Bug

ReadingQueueManager.estimatedTimeToEmpty() checked minutes < 1 before checking if the queue was actually empty. A queue with pending items whose total estimated reading time was under 1 minute would incorrectly show 'Queue empty' instead of a time estimate.

## Fix

- Check pendingItems().isEmpty first via guard clause
- Show <1min for sub-minute totals instead of misleading 'Queue empty'
- Guard _totalSizeBytes against underflow in OfflineCacheManager.removeOldest()